### PR TITLE
fix: 修复 Input 类组件的默认 props

### DIFF
--- a/packages/antd-lowcode-materials/lowcode/auto-complete/meta.ts
+++ b/packages/antd-lowcode-materials/lowcode/auto-complete/meta.ts
@@ -148,6 +148,259 @@ export default {
     },
   ],
   configure: {
+    props: [
+      {
+        name: 'defaultValue',
+        title: {
+          label: {
+            type: 'i18n',
+            zh_CN: '默认值',
+            en_US: 'Default Value',
+          },
+          tip: {
+            type: 'i18n',
+            zh_CN: '属性: defaultValue | 说明: 默认值',
+            en_US: 'prop: defaultValue | description: defaultValue',
+          },
+        },
+        setter: 'StringSetter',
+        supportVariable: true,
+      },
+      {
+        name: 'value',
+        title: {
+          label: {
+            type: 'i18n',
+            zh_CN: '当前值',
+            en_US: 'Value',
+          },
+          tip: {
+            type: 'i18n',
+            zh_CN: '属性: Value | 说明: 当前值',
+            en_US: 'prop: Value | description: Value',
+          },
+        },
+        setter: 'StringSetter',
+        supportVariable: true,
+      },
+      {
+        name: 'allowClear',
+        title: {
+          label: {
+            type: 'i18n',
+            zh_CN: '支持清除',
+            en_US: 'Allow Clear',
+          },
+          tip: {
+            type: 'i18n',
+            zh_CN: '属性: allowClear | 说明：是否允许清除',
+            en_US: 'prop: allowClear | description: Allow Clear',
+          }
+        },
+        setter: 'BoolSetter',
+        supportVariable: true,
+      },
+      {
+        name: 'options',
+        title: {
+          label: {
+            type: 'i18n',
+            zh_CN: '选项内容',
+            en_US: 'Options',
+          },
+          tip: {
+            type: 'i18n',
+            zh_CN: '属性: options | 说明：选项列表',
+            en_US: 'prop: options | description: Options',
+          }
+        },
+        setter: {
+          componentName: 'ArraySetter',
+          props: {
+            itemSetter: {
+              componentName: 'ObjectSetter',
+              props: {
+                config: {
+                  items: [
+                    {
+                      name: 'label',
+                      title: '选项名',
+                      setter: 'StringSetter',
+                    },
+                    {
+                      name: 'value',
+                      title: '选项值',
+                      setter: 'StringSetter',
+                    },
+                  ],
+                },
+              },
+              initialValue: () => {
+                return {
+                  label: '选项名',
+                  value: uuid(),
+                };
+              },
+            },
+          },
+        },
+      },
+      {
+        name: 'autoFocus',
+        title: {
+          label: {
+            type: 'i18n',
+            zh_CN: '自动聚焦',
+            en_US: 'Auto Focus',
+          },
+          tip: {
+            type: 'i18n',
+            zh_CN: '属性: autoFocus | 说明：自动获取焦点',
+            en_US: 'prop: autoFocus | description: Auto Focus',
+          }
+        },
+        setter: 'BoolSetter',
+        supportVariable: true,
+      },
+      {
+        name: 'backfill',
+        title: {
+          label: {
+            type: 'i18n',
+            zh_CN: '键盘选中回填',
+            en_US: 'Backfill',
+          },
+          tip: {
+            type: 'i18n',
+            zh_CN: '属性: backfill | 说明：使用键盘选择选项的时候把选中项回填到输入框中',
+            en_US: 'prop: backfill | description: When using the keyboard to select options, backfill the selected items into the input box',
+          }
+        },
+        setter: 'BoolSetter',
+        supportVariable: true,
+      },
+      {
+        name: 'defaultActiveFirstOption',
+        title: {
+          label: {
+            type: 'i18n',
+            zh_CN: '默认高亮首个选项',
+            en_US: 'Default Active First Option',
+          },
+          tip: {
+            type: 'i18n',
+            zh_CN: '属性: defaultActiveFirstOption | 说明：是否默认高亮第一个选项',
+            en_US: 'prop: defaultActiveFirstOption | description: Whether to highlight the first option by default',
+          }
+        },
+        setter: 'BoolSetter',
+        defaultValue: true,
+        supportVariable: true,
+      },
+      {
+        name: 'disabled',
+        title: {
+          label: {
+            type: 'i18n',
+            zh_CN: '是否禁用',
+            en_US: 'Disabled',
+          },
+          tip: {
+            type: 'i18n',
+            zh_CN: '属性: disabled | 说明：是否为禁用状态',
+            en_US: 'prop: disabled | description: Disable',
+          }
+        },
+        setter: 'BoolSetter',
+        supportVariable: true,
+      },
+      {
+        name: 'filterOption',
+        title: {
+          label: {
+            type: 'i18n',
+            zh_CN: '可选项筛选',
+            en_US: 'Filter Option',
+          },
+          tip: {
+            type: 'i18n',
+            zh_CN: '属性: filterOption | 说明：是否根据输入项进行筛选',
+            en_US: 'prop: filterOption | description: Filter based on input',
+          }
+        },
+        setter: 'BoolSetter',
+        supportVariable: true,
+      },
+      {
+        name: 'placeholder',
+        title: {
+          label: {
+            type: 'i18n',
+            zh_CN: '输入框提示',
+            en_US: 'Placeholder',
+          },
+          tip: {
+            type: 'i18n',
+            zh_CN: '属性: placeholder | 说明: 输入框提示',
+            en_US: 'prop: placeholder | description: Placeholder',
+          },
+        },
+        setter: 'StringSetter',
+        supportVariable: true,
+      },
+      {
+        name: 'defaultOpen',
+        propType: 'bool',
+        title: {
+          label: {
+            type: 'i18n',
+            zh_CN: '默认展开菜单',
+            en_US: 'Default Open',
+          },
+          tip: {
+            type: 'i18n',
+            zh_CN: '属性: defaultOpen | 说明：是否默认展开下拉菜单',
+            en_US: 'prop: defaultOpen | description: Expand drop-down menu by default',
+          }
+        },
+        setter: 'BoolSetter',
+        supportVariable: true,
+      },
+      {
+        name: 'open',
+        title: {
+          label: {
+            type: 'i18n',
+            zh_CN: '展开下拉菜单',
+            en_US: 'Open',
+          },
+          tip: {
+            type: 'i18n',
+            zh_CN: '属性: open | 说明：是否展开下拉菜单',
+            en_US: 'prop: open | description: Expand drop-down menu',
+          }
+        },
+        setter: 'BoolSetter',
+        supportVariable: true,
+      },
+      {
+        name: 'notFoundContent',
+        title: {
+          label: {
+            type: 'i18n',
+            zh_CN: '无数据展示',
+            en_US: 'Not Found Content',
+          },
+          tip: {
+            type: 'i18n',
+            zh_CN: '属性: notFoundContent | 说明: 当下拉列表为空时显示的内容',
+            en_US: 'prop: notFoundContent | description: Content displayed when the drop-down list is empty',
+          },
+        },
+        setter: 'StringSetter',
+        supportVariable: true,
+      },
+    ],
     supports: {
       style: true,
       events: [

--- a/packages/antd-lowcode-materials/lowcode/cascader/meta.ts
+++ b/packages/antd-lowcode-materials/lowcode/cascader/meta.ts
@@ -32,18 +32,21 @@ export default {
       title: { label: '支持清除', tip: '是否允许清除' },
       propType: 'bool',
       defaultValue: true,
+      setter: 'BoolSetter'
     },
     {
       name: 'autoFocus',
       title: { label: '自动聚焦', tip: '自动获取焦点' },
       propType: 'bool',
       defaultValue: false,
+      setter: 'BoolSetter'
     },
     {
       name: 'bordered',
       title: { label: '显示边框', tip: '是否有边框' },
       propType: 'bool',
       defaultValue: true,
+      setter: 'BoolSetter'
     },
     {
       name: 'changeOnSelect',
@@ -53,17 +56,20 @@ export default {
       },
       propType: 'bool',
       defaultValue: false,
+      setter: 'BoolSetter'
     },
     {
       name: 'className',
       title: { label: '自定义类名', tip: '自定义类名' },
       propType: 'string',
+      setter: 'StringSetter'
     },
     {
       name: 'disabled',
       title: { label: '是否禁用', tip: '是否为禁用状态' },
       propType: 'bool',
       defaultValue: false,
+      setter: 'BoolSetter'
     },
     {
       name: 'expandTrigger',
@@ -74,16 +80,19 @@ export default {
       name: 'notFoundContent',
       title: { label: '无数据展示', tip: '无数据' },
       propType: 'string',
+      setter: 'StringSetter'
     },
     {
       name: 'placeholder',
       title: { label: '输入框占位文本', tip: '输入框占位文本' },
       propType: 'string',
+      setter: 'StringSetter'
     },
     {
       name: 'popupClassName',
       title: { label: '自定义浮层类名', tip: '自定义浮层类名' },
       propType: 'string',
+      setter: 'StringSetter'
     },
     {
       name: 'popupPlacement',
@@ -97,12 +106,14 @@ export default {
       name: 'popupVisible',
       title: { label: '控制浮层显隐', tip: '控制浮层显隐' },
       propType: 'bool',
+      setter: 'BoolSetter'
     },
     {
       name: 'showSearch',
       title: { label: '支持搜索', tip: '在选择框中显示搜索框' },
       propType: 'bool',
       defaultValue: false,
+      setter: 'BoolSetter'
     },
     {
       name: 'size',
@@ -127,81 +138,6 @@ export default {
     },
   ],
   configure: {
-    props: {
-      isExtends: true,
-      override: [
-        {
-          name: 'allowClear',
-          title: {
-            label: {
-              type: 'i18n',
-              zh_CN: '支持清除',
-              en_US: 'Allow Clear',
-            },
-            tip: {
-              type: 'i18n',
-              zh_CN: '属性: allowClear | 说明: 是否允许清除',
-              en_US: 'prop: allowClear | description: Allow clear',
-            },
-          },
-          setter: 'BoolSetter',
-          supportVariable: true,
-          defaultValue: true,
-        },
-        {
-          name: 'bordered',
-          title: {
-            label: {
-              type: 'i18n',
-              zh_CN: '显示边框',
-              en_US: 'ShowBorder',
-            },
-            tip: {
-              type: 'i18n',
-              zh_CN: '属性: bordered | 说明: 是否有边框',
-              en_US: 'prop: bordered | description: have border',
-            },
-          },
-          setter: 'BoolSetter',
-          supportVariable: true,
-          defaultValue: true
-        },
-        {
-          name: 'popupVisible',
-          title: {
-            label: {
-              type: 'i18n',
-              zh_CN: '控制浮层显隐',
-              en_US: 'Popup Visible',
-            },
-            tip: {
-              type: 'i18n',
-              zh_CN: '属性: popupVisible | 说明: 控制浮层显隐',
-              en_US: 'prop: popupVisible | description: Popup Visible',
-            },
-          },
-          setter: 'BoolSetter',
-          supportVariable: true
-        },
-        {
-          name: 'value',
-          title: {
-            label: {
-              type: 'i18n',
-              zh_CN: '当前选中项',
-              en_US: 'Value',
-            },
-            tip: {
-              type: 'i18n',
-              zh_CN: '属性: value | 说明: 当前选中项',
-              en_US: 'prop: value | description: Value',
-            },
-          },
-          setter: 'ArraySetter',
-          supportVariable: true
-        }
-      ]
-    },
     supports: {
       style: true,
       events: [

--- a/packages/antd-lowcode-materials/lowcode/cascader/meta.ts
+++ b/packages/antd-lowcode-materials/lowcode/cascader/meta.ts
@@ -127,6 +127,81 @@ export default {
     },
   ],
   configure: {
+    props: {
+      isExtends: true,
+      override: [
+        {
+          name: 'allowClear',
+          title: {
+            label: {
+              type: 'i18n',
+              zh_CN: '支持清除',
+              en_US: 'Allow Clear',
+            },
+            tip: {
+              type: 'i18n',
+              zh_CN: '属性: allowClear | 说明: 是否允许清除',
+              en_US: 'prop: allowClear | description: Allow clear',
+            },
+          },
+          setter: 'BoolSetter',
+          supportVariable: true,
+          defaultValue: true,
+        },
+        {
+          name: 'bordered',
+          title: {
+            label: {
+              type: 'i18n',
+              zh_CN: '显示边框',
+              en_US: 'ShowBorder',
+            },
+            tip: {
+              type: 'i18n',
+              zh_CN: '属性: bordered | 说明: 是否有边框',
+              en_US: 'prop: bordered | description: have border',
+            },
+          },
+          setter: 'BoolSetter',
+          supportVariable: true,
+          defaultValue: true
+        },
+        {
+          name: 'popupVisible',
+          title: {
+            label: {
+              type: 'i18n',
+              zh_CN: '控制浮层显隐',
+              en_US: 'Popup Visible',
+            },
+            tip: {
+              type: 'i18n',
+              zh_CN: '属性: popupVisible | 说明: 控制浮层显隐',
+              en_US: 'prop: popupVisible | description: Popup Visible',
+            },
+          },
+          setter: 'BoolSetter',
+          supportVariable: true
+        },
+        {
+          name: 'value',
+          title: {
+            label: {
+              type: 'i18n',
+              zh_CN: '当前选中项',
+              en_US: 'Value',
+            },
+            tip: {
+              type: 'i18n',
+              zh_CN: '属性: value | 说明: 当前选中项',
+              en_US: 'prop: value | description: Value',
+            },
+          },
+          setter: 'ArraySetter',
+          supportVariable: true
+        }
+      ]
+    },
     supports: {
       style: true,
       events: [

--- a/packages/antd-lowcode-materials/lowcode/input-number/meta.ts
+++ b/packages/antd-lowcode-materials/lowcode/input-number/meta.ts
@@ -23,30 +23,35 @@ export default {
       title: { label: '自动聚焦', tip: '自动获取焦点' },
       propType: 'bool',
       defaultValue: false,
+      setter: 'BoolSetter'
     },
     {
       name: 'disabled',
       title: { label: '是否禁用', tip: '是否为禁用状态' },
       propType: 'bool',
       defaultValue: false,
+      setter: 'BoolSetter'
     },
     {
       name: 'placeholder',
       title: { label: '占位提示', tip: '占位提示' },
       propType: 'string',
       defaultValue: '请输入',
+      setter: 'StringSetter'
     },
     {
       name: 'controls',
       title: { label: '是否显示增减按钮', tip: '是否显示增减按钮' },
       propType: 'bool',
       defaultValue: true,
+      setter: 'BoolSetter'
     },
     {
       name: 'bordered',
       title: { label: '显示边框', tip: '是否有边框' },
       propType: 'bool',
       defaultValue: true,
+      setter: 'BoolSetter'
     },
     {
       name: 'addonAfter',
@@ -70,16 +75,19 @@ export default {
       name: 'max',
       title: { label: '最大值', tip: '最大值' },
       propType: 'number',
+      setter: 'NumberSetter'
     },
     {
       name: 'min',
       title: { label: '最小值', tip: '最小值' },
       propType: 'number',
+      setter: 'NumberSetter'
     },
     {
       name: 'precision',
       title: { label: '数值精度', tip: '数值精度' },
       propType: 'number',
+      setter: 'NumberSetter'
     },
     // {
     //   name: 'decimalSeparator',
@@ -115,6 +123,7 @@ export default {
       name: 'step',
       title: { label: '单步长', tip: '每次改变步数' },
       propType: 'number',
+      setter: 'NumberSetter'
     },
     {
       name: 'onChange',
@@ -153,29 +162,6 @@ export default {
     },
   ],
   configure: {
-    props: {
-      isExtends: true,
-      override: [
-        {
-          name: 'bordered',
-          title: {
-            label: {
-              type: 'i18n',
-              zh_CN: '显示边框',
-              en_US: 'ShowBorder',
-            },
-            tip: {
-              type: 'i18n',
-              zh_CN: '属性: bordered | 说明: 是否有边框',
-              en_US: 'prop: bordered | description: have border',
-            },
-          },
-          setter: 'BoolSetter',
-          supportVariable: true,
-          defaultValue: true
-        }
-      ]
-    },
     supports: {
       style: true,
       events: [

--- a/packages/antd-lowcode-materials/lowcode/input-number/meta.ts
+++ b/packages/antd-lowcode-materials/lowcode/input-number/meta.ts
@@ -153,6 +153,29 @@ export default {
     },
   ],
   configure: {
+    props: {
+      isExtends: true,
+      override: [
+        {
+          name: 'bordered',
+          title: {
+            label: {
+              type: 'i18n',
+              zh_CN: '显示边框',
+              en_US: 'ShowBorder',
+            },
+            tip: {
+              type: 'i18n',
+              zh_CN: '属性: bordered | 说明: 是否有边框',
+              en_US: 'prop: bordered | description: have border',
+            },
+          },
+          setter: 'BoolSetter',
+          supportVariable: true,
+          defaultValue: true
+        }
+      ]
+    },
     supports: {
       style: true,
       events: [

--- a/packages/antd-lowcode-materials/lowcode/input.group/meta.ts
+++ b/packages/antd-lowcode-materials/lowcode/input.group/meta.ts
@@ -10,6 +10,7 @@ export default {
       name: 'compact',
       title: { label: '紧凑模式', tip: '是否用紧凑模式' },
       propType: 'bool',
+      setter: 'BoolSetter'
     },
     {
       name: 'size',

--- a/packages/antd-lowcode-materials/lowcode/input.password/meta.ts
+++ b/packages/antd-lowcode-materials/lowcode/input.password/meta.ts
@@ -134,6 +134,47 @@ export default {
     },
   ],
   configure: {
+    props: {
+      isExtends: true,
+      override: [
+        {
+          name: 'bordered',
+          title: {
+            label: {
+              type: 'i18n',
+              zh_CN: '显示边框',
+              en_US: 'ShowBorder',
+            },
+            tip: {
+              type: 'i18n',
+              zh_CN: '属性: bordered | 说明: 是否有边框',
+              en_US: 'prop: bordered | description: have border',
+            },
+          },
+          setter: 'BoolSetter',
+          supportVariable: true,
+          defaultValue: true
+        },
+        {
+          name: 'maxLength',
+          title: {
+            label: {
+              type: 'i18n',
+              zh_CN: '最大长度',
+              en_US: 'MaxLength',
+            },
+            tip: {
+              type: 'i18n',
+              zh_CN: '属性: maxLength | 说明: 最大长度',
+              en_US: 'prop: maxLength | description: max length',
+            },
+          },
+          setter: 'NumberSetter',
+          supportVariable: true,
+          description: '最大长度',
+        }
+      ]
+    },
     supports: {
       style: true,
       events: [

--- a/packages/antd-lowcode-materials/lowcode/input.password/meta.ts
+++ b/packages/antd-lowcode-materials/lowcode/input.password/meta.ts
@@ -22,30 +22,35 @@ export default {
       name: 'allowClear',
       title: { label: '支持清除', tip: '是否允许清除' },
       propType: 'bool',
+      setter: 'BoolSetter',
     },
     {
       name: 'bordered',
       title: { label: '显示边框', tip: '是否有边框' },
       propType: 'bool',
       defaultValue: true,
+      setter: 'BoolSetter'
     },
     {
       name: 'disabled',
       title: { label: '是否禁用', tip: '是否为禁用状态' },
       propType: 'bool',
       defaultValue: false,
+      setter: 'BoolSetter'
     },
     {
       name: 'visibilityToggle',
       title: { label: '切换按钮', tip: '是否显示切换按钮' },
       propType: 'bool',
       defaultValue: true,
+      setter: 'BoolSetter'
     },
     {
       name: 'placeholder',
       title: { label: '占位提示', tip: '占位提示' },
       propType: 'string',
       defaultValue: '请输入',
+      setter: 'StringSetter'
     },
     // {
     //   name: 'id',
@@ -56,6 +61,7 @@ export default {
       name: 'maxLength',
       title: { label: '最大长度', tip: '最大长度' },
       propType: 'number',
+      setter: 'NumberSetter'
     },
     {
       name: 'size',
@@ -134,47 +140,6 @@ export default {
     },
   ],
   configure: {
-    props: {
-      isExtends: true,
-      override: [
-        {
-          name: 'bordered',
-          title: {
-            label: {
-              type: 'i18n',
-              zh_CN: '显示边框',
-              en_US: 'ShowBorder',
-            },
-            tip: {
-              type: 'i18n',
-              zh_CN: '属性: bordered | 说明: 是否有边框',
-              en_US: 'prop: bordered | description: have border',
-            },
-          },
-          setter: 'BoolSetter',
-          supportVariable: true,
-          defaultValue: true
-        },
-        {
-          name: 'maxLength',
-          title: {
-            label: {
-              type: 'i18n',
-              zh_CN: '最大长度',
-              en_US: 'MaxLength',
-            },
-            tip: {
-              type: 'i18n',
-              zh_CN: '属性: maxLength | 说明: 最大长度',
-              en_US: 'prop: maxLength | description: max length',
-            },
-          },
-          setter: 'NumberSetter',
-          supportVariable: true,
-          description: '最大长度',
-        }
-      ]
-    },
     supports: {
       style: true,
       events: [

--- a/packages/antd-lowcode-materials/lowcode/input.search/meta.ts
+++ b/packages/antd-lowcode-materials/lowcode/input.search/meta.ts
@@ -143,6 +143,29 @@ export default {
     },
   ],
   configure: {
+    props: {
+      isExtends: true,
+      override: [
+        {
+          name: 'bordered',
+          title: {
+            label: {
+              type: 'i18n',
+              zh_CN: '显示边框',
+              en_US: 'ShowBorder',
+            },
+            tip: {
+              type: 'i18n',
+              zh_CN: '属性: bordered | 说明: 是否有边框',
+              en_US: 'prop: bordered | description: have border',
+            },
+          },
+          setter: 'BoolSetter',
+          supportVariable: true,
+          defaultValue: true
+        }
+      ]
+    },
     supports: {
       style: true,
       events: [

--- a/packages/antd-lowcode-materials/lowcode/input.search/meta.ts
+++ b/packages/antd-lowcode-materials/lowcode/input.search/meta.ts
@@ -10,34 +10,40 @@ export default {
       name: 'defaultValue',
       title: { label: '默认值', tip: '默认值' },
       propType: 'string',
+      setter: 'StringSetter'
     },
     {
       name: 'value',
       title: { label: '当前值', tip: '当前值' },
       propType: 'string',
+      setter: 'StringSetter'
     },
     {
       name: 'bordered',
       title: { label: '显示边框', tip: '是否有边框' },
       propType: 'bool',
       defaultValue: true,
+      setter: 'BoolSetter'
     },
     {
       name: 'loading',
       title: { label: '加载状态', tip: 'loading' },
       propType: 'bool',
+      setter: 'BoolSetter'
     },
     {
       name: 'disabled',
       title: { label: '是否禁用', tip: '是否为禁用状态' },
       propType: 'bool',
       defaultValue: false,
+      setter: 'BoolSetter'
     },
     {
       name: 'placeholder',
       title: { label: '占位提示', tip: '占位提示' },
       propType: 'string',
       defaultValue: '请输入',
+      setter: 'StringSetter'
     },
     // {
     //   name: 'id',
@@ -143,29 +149,6 @@ export default {
     },
   ],
   configure: {
-    props: {
-      isExtends: true,
-      override: [
-        {
-          name: 'bordered',
-          title: {
-            label: {
-              type: 'i18n',
-              zh_CN: '显示边框',
-              en_US: 'ShowBorder',
-            },
-            tip: {
-              type: 'i18n',
-              zh_CN: '属性: bordered | 说明: 是否有边框',
-              en_US: 'prop: bordered | description: have border',
-            },
-          },
-          setter: 'BoolSetter',
-          supportVariable: true,
-          defaultValue: true
-        }
-      ]
-    },
     supports: {
       style: true,
       events: [

--- a/packages/antd-lowcode-materials/lowcode/input.text-area/meta.ts
+++ b/packages/antd-lowcode-materials/lowcode/input.text-area/meta.ts
@@ -23,34 +23,40 @@ export default {
       title: { label: '显示边框', tip: '是否有边框' },
       propType: 'bool',
       defaultValue: true,
+      setter: 'BoolSetter'
     },
     {
       name: 'disabled',
       title: { label: '是否禁用', tip: '是否为禁用状态' },
       propType: 'bool',
       defaultValue: false,
+      setter: 'BoolSetter'
     },
     {
       name: 'placeholder',
       title: { label: '占位提示', tip: '占位提示' },
       propType: 'string',
       defaultValue: '请输入',
+      setter: 'StringSetter'
     },
     {
       name: 'showCount',
       title: { label: '展示字数', tip: '是否展示字数' },
       propType: 'bool',
       defaultValue: false,
+      setter: 'BoolSetter'
     },
     {
       name: 'id',
       title: { label: '输入框ID', tip: '输入框的ID' },
       propType: 'string',
+      setter: 'StringSetter'
     },
     {
       name: 'maxLength',
       title: { label: '最大长度', tip: '最大长度' },
       propType: 'number',
+      setter: 'NumberSetter'
     },
     {
       name: 'size',
@@ -147,47 +153,6 @@ export default {
     },
   ],
   configure: {
-    props: {
-      isExtends: true,
-      override: [
-        {
-          name: 'bordered',
-          title: {
-            label: {
-              type: 'i18n',
-              zh_CN: '显示边框',
-              en_US: 'ShowBorder',
-            },
-            tip: {
-              type: 'i18n',
-              zh_CN: '属性: bordered | 说明: 是否有边框',
-              en_US: 'prop: bordered | description: have border',
-            },
-          },
-          setter: 'BoolSetter',
-          supportVariable: true,
-          defaultValue: true
-        },
-        {
-          name: 'maxLength',
-          title: {
-            label: {
-              type: 'i18n',
-              zh_CN: '最大长度',
-              en_US: 'MaxLength',
-            },
-            tip: {
-              type: 'i18n',
-              zh_CN: '属性: maxLength | 说明: 最大长度',
-              en_US: 'prop: maxLength | description: max length',
-            },
-          },
-          setter: 'NumberSetter',
-          supportVariable: true,
-          description: '最大长度',
-        }
-      ]
-    },
     supports: {
       style: true,
       events: [

--- a/packages/antd-lowcode-materials/lowcode/input.text-area/meta.ts
+++ b/packages/antd-lowcode-materials/lowcode/input.text-area/meta.ts
@@ -147,6 +147,47 @@ export default {
     },
   ],
   configure: {
+    props: {
+      isExtends: true,
+      override: [
+        {
+          name: 'bordered',
+          title: {
+            label: {
+              type: 'i18n',
+              zh_CN: '显示边框',
+              en_US: 'ShowBorder',
+            },
+            tip: {
+              type: 'i18n',
+              zh_CN: '属性: bordered | 说明: 是否有边框',
+              en_US: 'prop: bordered | description: have border',
+            },
+          },
+          setter: 'BoolSetter',
+          supportVariable: true,
+          defaultValue: true
+        },
+        {
+          name: 'maxLength',
+          title: {
+            label: {
+              type: 'i18n',
+              zh_CN: '最大长度',
+              en_US: 'MaxLength',
+            },
+            tip: {
+              type: 'i18n',
+              zh_CN: '属性: maxLength | 说明: 最大长度',
+              en_US: 'prop: maxLength | description: max length',
+            },
+          },
+          setter: 'NumberSetter',
+          supportVariable: true,
+          description: '最大长度',
+        }
+      ]
+    },
     supports: {
       style: true,
       events: [

--- a/packages/antd-lowcode-materials/lowcode/input/meta.ts
+++ b/packages/antd-lowcode-materials/lowcode/input/meta.ts
@@ -133,6 +133,47 @@ export default {
     },
   ],
   configure: {
+    props: {
+      isExtends: true,
+      override: [
+        {
+          name: 'bordered',
+          title: {
+            label: {
+              type: 'i18n',
+              zh_CN: '显示边框',
+              en_US: 'ShowBorder',
+            },
+            tip: {
+              type: 'i18n',
+              zh_CN: '属性: bordered | 说明: 是否有边框',
+              en_US: 'prop: bordered | description: have border',
+            },
+          },
+          setter: 'BoolSetter',
+          supportVariable: true,
+          defaultValue: true
+        },
+        {
+          name: 'maxLength',
+          title: {
+            label: {
+              type: 'i18n',
+              zh_CN: '最大长度',
+              en_US: 'MaxLength',
+            },
+            tip: {
+              type: 'i18n',
+              zh_CN: '属性: maxLength | 说明: 最大长度',
+              en_US: 'prop: maxLength | description: max length',
+            },
+          },
+          setter: 'NumberSetter',
+          supportVariable: true,
+          description: '最大长度',
+        }
+      ]
+    },
     supports: {
       style: true,
       events: [

--- a/packages/antd-lowcode-materials/lowcode/input/meta.ts
+++ b/packages/antd-lowcode-materials/lowcode/input/meta.ts
@@ -16,30 +16,34 @@ export default {
       name: 'value',
       title: { label: '当前值', tip: '当前值' },
       propType: 'string',
-      setter: 'StringSetter',
+      setter: 'StringSetter'
     },
     {
       name: 'allowClear',
       title: { label: '支持清除', tip: '是否允许清除' },
       propType: 'bool',
+      setter: 'BoolSetter',
     },
     {
       name: 'bordered',
       title: { label: '显示边框', tip: '是否有边框' },
       propType: 'bool',
       defaultValue: true,
+      setter: 'BoolSetter',
     },
     {
       name: 'disabled',
       title: { label: '是否禁用', tip: '是否为禁用状态' },
       propType: 'bool',
       defaultValue: false,
+      setter: 'BoolSetter',
     },
     {
       name: 'placeholder',
       title: { label: '占位提示', tip: '占位提示' },
       propType: 'string',
       defaultValue: '请输入',
+      setter: 'StringSetter'
     },
     // {
     //   name: 'id',
@@ -50,6 +54,7 @@ export default {
       name: 'maxLength',
       title: { label: '最大长度', tip: '最大长度' },
       propType: 'number',
+      setter: 'NumberSetter',
     },
     {
       name: 'size',
@@ -133,47 +138,6 @@ export default {
     },
   ],
   configure: {
-    props: {
-      isExtends: true,
-      override: [
-        {
-          name: 'bordered',
-          title: {
-            label: {
-              type: 'i18n',
-              zh_CN: '显示边框',
-              en_US: 'ShowBorder',
-            },
-            tip: {
-              type: 'i18n',
-              zh_CN: '属性: bordered | 说明: 是否有边框',
-              en_US: 'prop: bordered | description: have border',
-            },
-          },
-          setter: 'BoolSetter',
-          supportVariable: true,
-          defaultValue: true
-        },
-        {
-          name: 'maxLength',
-          title: {
-            label: {
-              type: 'i18n',
-              zh_CN: '最大长度',
-              en_US: 'MaxLength',
-            },
-            tip: {
-              type: 'i18n',
-              zh_CN: '属性: maxLength | 说明: 最大长度',
-              en_US: 'prop: maxLength | description: max length',
-            },
-          },
-          setter: 'NumberSetter',
-          supportVariable: true,
-          description: '最大长度',
-        }
-      ]
-    },
     supports: {
       style: true,
       events: [

--- a/packages/antd-lowcode-materials/lowcode/mentions/meta.ts
+++ b/packages/antd-lowcode-materials/lowcode/mentions/meta.ts
@@ -10,12 +10,14 @@ export default {
       name: 'defaultValue',
       title: { label: '默认值', tip: '默认值' },
       propType: 'string',
+      setter: 'StringSetter'
     },
     {
       name: 'autoFocus',
       title: { label: '自动聚焦', tip: '自动获得焦点' },
       propType: 'bool',
       defaultValue: false,
+      setter: 'BoolSetter'
     },
     {
       name: 'filterOption',

--- a/packages/antd-lowcode-materials/lowcode/rate/meta.ts
+++ b/packages/antd-lowcode-materials/lowcode/rate/meta.ts
@@ -10,24 +10,28 @@ export default {
       name: 'defaultValue',
       title: { label: '默认值', tip: '默认值' },
       propType: 'number',
+      setter: 'NumberSetter'
     },
     {
       name: 'allowClear',
       title: { label: '支持清除', tip: '是否允许清除' },
       propType: 'bool',
       defaultValue: true,
+      setter: 'BoolSetter'
     },
     {
       name: 'allowHalf',
       title: { label: '支持半选', tip: '支持半选' },
       propType: 'bool',
       defaultValue: false,
+      setter: 'BoolSetter'
     },
     {
       name: 'autoFocus',
       title: { label: '自动聚焦', tip: '自动获取焦点' },
       propType: 'bool',
       defaultValue: false,
+      setter: 'BoolSetter'
     },
     {
       name: 'character',
@@ -39,6 +43,7 @@ export default {
       title: { label: '总数', tip: 'star 总数' },
       propType: 'number',
       defaultValue: 5,
+      setter: 'NumberSetter'
     },
     // {
     //   name: 'value',
@@ -51,6 +56,7 @@ export default {
       title: { label: '是否禁用', tip: '是否为禁用状态' },
       propType: 'bool',
       defaultValue: false,
+      setter: 'BoolSetter'
     },
     {
       name: 'tooltips',

--- a/packages/antd-lowcode-materials/lowcode/select/meta.ts
+++ b/packages/antd-lowcode-materials/lowcode/select/meta.ts
@@ -95,24 +95,28 @@ export default {
       title: { label: '支持清除', tip: '是否允许清除' },
       propType: 'bool',
       defaultValue: false,
+      setter: 'BoolSetter'
     },
     {
       name: 'autoFocus',
       title: { label: '自动聚焦', tip: '默认获取焦点' },
       propType: 'bool',
       defaultValue: false,
+      setter: 'BoolSetter'
     },
     {
       name: 'defaultActiveFirstOption',
       title: { label: '高亮首个选项', tip: '是否默认高亮第一个选项' },
       propType: 'bool',
       defaultValue: true,
+      setter: 'BoolSetter'
     },
     {
       name: 'disabled',
       title: { label: '是否禁用', tip: '是否为禁用状态' },
       propType: 'bool',
       defaultValue: false,
+      setter: 'BoolSetter'
     },
     {
       name: 'labelInValue',
@@ -122,6 +126,7 @@ export default {
       },
       propType: 'bool',
       defaultValue: false,
+      setter: 'BoolSetter'
     },
     {
       name: 'mode',
@@ -167,22 +172,26 @@ export default {
       name: 'notFoundContent',
       title: { label: '搜索为空提示文案', tip: '搜索为空提示文案' },
       propType: 'string',
+      setter: 'StringSetter'
     },
     {
       name: 'placeholder',
       title: { label: '选择框默认文字', tip: '选择框默认文字' },
       propType: 'string',
+      setter: 'StringSetter'
     },
     {
       name: 'showArrow',
       title: { label: '是否显示下拉箭头', tip: '是否显示下拉小箭头' },
       propType: 'bool',
+      setter: 'BoolSetter'
     },
     {
       name: 'showSearch',
       title: { label: '是否可搜索', tip: '是否可搜索' },
       propType: 'bool',
       defaultValue: false,
+      setter: 'BoolSetter'
     },
     {
       name: 'size',
@@ -214,12 +223,14 @@ export default {
       title: { label: '加载中', tip: '加载中状态' },
       propType: 'bool',
       defaultValue: false,
+      setter: 'BoolSetter'
     },
     {
       name: 'bordered',
       title: { label: '显示边框', tip: '是否有边框' },
       propType: 'bool',
       defaultValue: true,
+      setter: 'BoolSetter'
     },
     {
       name: 'filterOption',

--- a/packages/antd-lowcode-materials/lowcode/slider/meta.ts
+++ b/packages/antd-lowcode-materials/lowcode/slider/meta.ts
@@ -22,6 +22,7 @@ export default {
       title: { label: '双滑块模式', tip: '双滑块模式' },
       propType: 'bool',
       defaultValue: false,
+      setter: 'BoolSetter',
       setValue(target, range) {
         let defaultValue = target.node.getPropValue('defaultValue');
         if (range) {
@@ -54,6 +55,7 @@ export default {
       },
       propType: 'bool',
       defaultValue: false,
+      setter: 'BoolSetter'
     },
     {
       name: 'disabled',
@@ -63,12 +65,14 @@ export default {
       },
       propType: 'bool',
       defaultValue: false,
+      setter: 'BoolSetter'
     },
     {
       name: 'dots',
       title: { label: '对齐刻度', tip: '是否只能拖拽到刻度上' },
       propType: 'bool',
       defaultValue: false,
+      setter: 'BoolSetter'
     },
     // {
     //   name: 'included',
@@ -95,17 +99,20 @@ export default {
       name: 'max',
       title: { label: '最大值', tip: '最大值' },
       propType: 'number',
+      setter: 'NumberSetter'
     },
     {
       name: 'min',
       title: { label: '最小值', tip: '最小值' },
       propType: 'number',
+      setter: 'NumberSetter'
     },
     {
       name: 'reverse',
       title: { label: '反向坐标轴', tip: '反向坐标轴' },
       propType: 'bool',
       defaultValue: false,
+      setter: 'BoolSetter'
     },
     {
       name: 'step',
@@ -115,6 +122,7 @@ export default {
           '步长，取值必须大于 0，并且可被 (max - min) 整除。当 `marks` 不为空对象时，可以设置 `step` 为 null，此时 Slider 的可选值仅有 marks 标出来的部分',
       },
       propType: 'number',
+      setter: 'NumberSetter'
     },
     // {
     //   name: 'tipFormatter',
@@ -134,6 +142,7 @@ export default {
       },
       propType: 'bool',
       defaultValue: false,
+      setter: 'BoolSetter'
     },
     {
       name: 'onAfterChange',

--- a/packages/antd-lowcode-materials/lowcode/switch/meta.ts
+++ b/packages/antd-lowcode-materials/lowcode/switch/meta.ts
@@ -11,34 +11,40 @@ export default {
       title: { label: '默认选中', tip: '默认是否选中' },
       propType: 'bool',
       defaultValue: false,
+      setter: 'BoolSetter'
     },
     {
       name: 'autoFocus',
       title: { label: '自动聚焦', tip: '组件自动获取焦点' },
       propType: 'bool',
       defaultValue: false,
+      setter: 'BoolSetter'
     },
     {
       name: 'checkedChildren',
       title: { label: '选中时内容', tip: '选中时的内容' },
       propType: 'string',
+      setter: 'StringSetter'
     },
     {
       name: 'unCheckedChildren',
       title: { label: '非选中时内容', tip: '非选中时的内容' },
       propType: 'string',
+      setter: 'StringSetter'
     },
     {
       name: 'disabled',
       title: { label: '是否禁用', tip: '是否为禁用状态' },
       propType: 'bool',
       defaultValue: false,
+      setter: 'BoolSetter'
     },
     {
       name: 'loading',
       title: { label: '加载中', tip: '加载中' },
       propType: 'bool',
       defaultValue: false,
+      setter: 'BoolSetter'
     },
     {
       name: 'size',

--- a/packages/antd-lowcode-materials/lowcode/time-picker/meta.ts
+++ b/packages/antd-lowcode-materials/lowcode/time-picker/meta.ts
@@ -23,34 +23,40 @@ export default {
       title: { label: '支持清除', tip: '是否允许清除' },
       propType: 'bool',
       defaultValue: true,
+      setter: 'BoolSetter'
     },
     {
       name: 'autoFocus',
       title: { label: '自动聚焦', tip: '自动获取焦点' },
       propType: 'bool',
       defaultValue: false,
+      setter: 'BoolSetter'
     },
     {
       name: 'bordered',
       title: { label: '显示边框', tip: '是否有边框' },
       propType: 'bool',
       defaultValue: true,
+      setter: 'BoolSetter'
     },
     {
       name: 'className',
       title: { label: '选择器类名', tip: '选择器类名' },
       propType: 'string',
+      setter: 'StringSetter'
     },
     {
       name: 'clearText',
       title: { label: '清除按钮的提示文案', tip: '清除按钮的提示文案' },
       propType: 'string',
+      setter: 'StringSetter'
     },
     {
       name: 'disabled',
       title: { label: '是否禁用', tip: '是否为禁用状态' },
       propType: 'bool',
       defaultValue: false,
+      setter: 'BoolSetter'
     },
     {
       name: 'disabledHours',
@@ -71,6 +77,7 @@ export default {
       name: 'format',
       title: { label: '展示的时间格式', tip: '展示的时间格式' },
       propType: 'string',
+      setter: 'StringSetter'
     },
     {
       name: 'getPopupContainer',
@@ -85,11 +92,13 @@ export default {
       title: { label: '隐藏禁止选择的选项', tip: '隐藏禁止选择的选项' },
       propType: 'bool',
       defaultValue: false,
+      setter: 'BoolSetter'
     },
     {
       name: 'hourStep',
       title: { label: '小时选项间隔', tip: '小时选项间隔' },
       propType: 'number',
+      setter: 'NumberSetter'
     },
     {
       name: 'inputReadOnly',
@@ -99,17 +108,20 @@ export default {
       },
       propType: 'bool',
       defaultValue: false,
+      setter: 'BoolSetter'
     },
     {
       name: 'minuteStep',
       title: { label: '分钟选项间隔', tip: '分钟选项间隔' },
       propType: 'number',
+      setter: 'NumberSetter'
     },
     {
       name: 'open',
       title: { label: '面板是否打开', tip: '面板是否打开' },
       propType: 'bool',
-      defaultValue: false,
+      // defaultValue: false,
+      setter: 'BoolSetter'
     },
     {
       name: 'placeholder',
@@ -123,6 +135,7 @@ export default {
       name: 'popupClassName',
       title: { label: '弹出层类名', tip: '弹出层类名' },
       propType: 'string',
+      setter: 'StringSetter'
     },
     // {
     //   name: 'popupStyle',
@@ -133,6 +146,7 @@ export default {
       name: 'secondStep',
       title: { label: '秒选项间隔', tip: '秒选项间隔' },
       propType: 'number',
+      setter: 'NumberSetter'
     },
     // {
     //   name: 'suffixIcon',
@@ -160,6 +174,7 @@ export default {
       },
       propType: 'bool',
       defaultValue: false,
+      setter: 'BoolSetter'
     },
     {
       name: 'onChange',
@@ -175,6 +190,7 @@ export default {
       name: 'showNow',
       title: { label: '“此刻”按钮', tip: '面板是否显示“此刻”按钮' },
       propType: 'bool',
+      setter: 'BoolSetter'
     },
   ],
   configure: {

--- a/packages/antd-lowcode-materials/lowcode/tree-select/meta.ts
+++ b/packages/antd-lowcode-materials/lowcode/tree-select/meta.ts
@@ -32,6 +32,7 @@ export default {
       title: { label: '支持清除', tip: '是否允许清除' },
       propType: 'bool',
       defaultValue: false,
+      setter: 'BoolSetter'
     },
     {
       name: 'autoClearSearchValue',
@@ -41,18 +42,21 @@ export default {
       },
       propType: 'bool',
       defaultValue: true,
+      setter: 'BoolSetter'
     },
     {
       name: 'bordered',
       title: { label: '显示边框', tip: '是否显示边框' },
       propType: 'bool',
       defaultValue: true,
+      setter: 'BoolSetter'
     },
     {
       name: 'disabled',
       title: { label: '是否禁用', tip: '是否为禁用状态' },
       propType: 'bool',
       defaultValue: false,
+      setter: 'BoolSetter'
     },
     // {
     //   name: 'dropdownClassName',
@@ -69,6 +73,7 @@ export default {
         tip: '下拉菜单和选择器同宽',
       },
       propType: 'bool',
+      setter: 'BoolSetter'
     },
     // {
     //   name: 'dropdownStyle',
@@ -82,6 +87,7 @@ export default {
         tip: '是否根据输入项进行筛选，默认用 treeNodeFilterProp 的值作为要筛选的 TreeNode 的属性值',
       },
       propType: 'bool',
+      setter: 'BoolSetter'
     },
     {
       name: 'labelInValue',
@@ -92,11 +98,13 @@ export default {
       },
       propType: 'bool',
       defaultValue: true,
+      setter: 'BoolSetter'
     },
     {
       name: 'listHeight',
       title: { label: '设置弹窗滚动高度', tip: '设置弹窗滚动高度' },
       propType: 'number',
+      setter: 'NumberSetter'
     },
     {
       name: 'loadData',
@@ -107,6 +115,7 @@ export default {
       name: 'maxTagCount',
       title: { label: '最多显示多少个 tag', tip: '最多显示多少个 tag' },
       propType: 'number',
+      setter: 'NumberSetter'
     },
     {
       name: 'maxTagPlaceholder',
@@ -121,11 +130,13 @@ export default {
       },
       propType: 'bool',
       defaultValue: false,
+      setter: 'BoolSetter'
     },
     {
       name: 'placeholder',
       title: { label: '选择框默认文字', tip: '选择框默认文字' },
       propType: 'string',
+      setter: 'StringSetter'
     },
     {
       name: 'showCheckedStrategy',
@@ -143,6 +154,7 @@ export default {
       name: 'showSearch',
       title: { label: '是否支持搜索框', tip: '是否支持搜索框' },
       propType: 'bool',
+      setter: 'BoolSetter'
     },
     {
       name: 'size',
@@ -157,6 +169,7 @@ export default {
         tip: '是否显示下拉图标，单选模式下默认 `true`',
       },
       propType: 'bool',
+      setter: 'BoolSetter'
     },
     // {
     //   name: 'suffixIcon',
@@ -173,22 +186,40 @@ export default {
       title: { label: '显示勾选框', tip: '显示勾选框' },
       propType: 'bool',
       defaultValue: false,
+      setter: 'BoolSetter'
     },
     {
       name: 'treeDefaultExpandAll',
       title: { label: '默认展开所有树节点', tip: '默认展开所有树节点' },
       propType: 'bool',
       defaultValue: false,
+      setter: 'BoolSetter'
     },
     {
       name: 'treeDefaultExpandedKeys',
       title: { label: '默认展开的树节点', tip: '默认展开的树节点' },
       propType: { type: 'arrayOf', value: 'string' },
+      setter: {
+        componentName: 'ArraySetter',
+        props: {
+          itemSetter: {
+            componentName: 'StringSetter',
+          }
+        }
+      }
     },
     {
       name: 'treeExpandedKeys',
       title: { label: '设置展开的树节点', tip: '设置展开的树节点' },
       propType: { type: 'arrayOf', value: 'string' },
+      setter: {
+        componentName: 'ArraySetter',
+        props: {
+          itemSetter: {
+            componentName: 'StringSetter',
+          }
+        }
+      }
     },
     {
       name: 'virtual',
@@ -198,6 +229,7 @@ export default {
       },
       propType: 'bool',
       defaultValue: true,
+      setter: 'BoolSetter'
     },
     {
       name: 'onChange',

--- a/packages/antd-lowcode-materials/lowcode/tree/meta.ts
+++ b/packages/antd-lowcode-materials/lowcode/tree/meta.ts
@@ -20,12 +20,14 @@ export default {
       title: { label: '是否自动展开父节点', tip: '是否自动展开父节点' },
       propType: 'bool',
       defaultValue: true,
+      setter: 'BoolSetter'
     },
     {
       name: 'blockNode',
       title: { label: '是否节点占据一行', tip: '是否节点占据一行' },
       propType: 'bool',
       defaultValue: false,
+      setter: 'BoolSetter'
     },
     {
       name: 'checkable',
@@ -35,6 +37,7 @@ export default {
       },
       propType: 'bool',
       defaultValue: false,
+      setter: 'BoolSetter'
     },
     {
       name: 'checkedKeys',
@@ -56,45 +59,74 @@ export default {
       },
       propType: 'bool',
       defaultValue: false,
+      setter: 'BoolSetter'
     },
     {
       name: 'defaultCheckedKeys',
       title: { label: '默认选中值', tip: '默认选中值' },
       propType: { type: 'arrayOf', value: 'string' },
+      setter: {
+        componentName: 'ArraySetter',
+        props: {
+          itemSetter: {
+            componentName: 'StringSetter',
+          }
+        }
+      },
     },
     {
       name: 'defaultExpandAll',
       title: { label: '默认展开所有树节点', tip: '默认展开所有树节点' },
       propType: 'bool',
       defaultValue: false,
+      setter: 'BoolSetter'
     },
     {
       name: 'defaultExpandedKeys',
       title: { label: '默认展开指定的树节点', tip: '默认展开指定的树节点' },
       propType: { type: 'arrayOf', value: 'string' },
+      setter: {
+        componentName: 'ArraySetter',
+        props: {
+          itemSetter: {
+            componentName: 'StringSetter',
+          }
+        }
+      },
     },
     {
       name: 'defaultExpandParent',
       title: { label: '默认展开父节点', tip: '默认展开父节点' },
       propType: 'bool',
       defaultValue: true,
+      setter: 'BoolSetter'
     },
     {
       name: 'defaultSelectedKeys',
       title: { label: '默认选中值', tip: '默认选中值' },
       propType: { type: 'arrayOf', value: 'string' },
+      setter: {
+        componentName: 'ArraySetter',
+        props: {
+          itemSetter: {
+            componentName: 'StringSetter',
+          }
+        }
+      },
     },
     {
       name: 'disabled',
       title: { label: '是否禁用', tip: '是否为禁用状态' },
       propType: 'bool',
       defaultValue: false,
+      setter: 'BoolSetter'
     },
     {
       name: 'draggable',
       title: { label: '节点可拖拽', tip: '设置节点可拖拽（IE>8）' },
       propType: 'bool',
       defaultValue: false,
+      setter: 'BoolSetter'
     },
     {
       name: 'expandedKeys',
@@ -103,6 +135,14 @@ export default {
         tip: '（受控）展开指定的树节点',
       },
       propType: { type: 'arrayOf', value: 'string' },
+      setter: {
+        componentName: 'ArraySetter',
+        props: {
+          itemSetter: {
+            componentName: 'StringSetter',
+          }
+        }
+      },
     },
     {
       name: 'filterTreeNode',
@@ -124,6 +164,14 @@ export default {
         tip: '（受控）已经加载的节点，需要配合 `loadData` 使用',
       },
       propType: { type: 'arrayOf', value: 'string' },
+      setter: {
+        componentName: 'ArraySetter',
+        props: {
+          itemSetter: {
+            componentName: 'StringSetter',
+          }
+        }
+      },
     },
     {
       name: 'multiple',
@@ -133,12 +181,14 @@ export default {
       },
       propType: 'bool',
       defaultValue: false,
+      setter: 'BoolSetter'
     },
     {
       name: 'selectable',
       title: { label: '是否可选中', tip: '是否可选中' },
       propType: 'bool',
       defaultValue: true,
+      setter: 'BoolSetter'
     },
     {
       name: 'selectedKeys',
@@ -147,6 +197,14 @@ export default {
         tip: '（受控）设置选中的树节点',
       },
       propType: { type: 'arrayOf', value: 'string' },
+      setter: {
+        componentName: 'ArraySetter',
+        props: {
+          itemSetter: {
+            componentName: 'StringSetter',
+          }
+        }
+      },
     },
     {
       name: 'showIcon',
@@ -157,6 +215,7 @@ export default {
       },
       propType: 'bool',
       defaultValue: false,
+      setter: 'BoolSetter'
     },
     // {
     //   name: 'switcherIcon',
@@ -179,6 +238,7 @@ export default {
       },
       propType: 'bool',
       defaultValue: true,
+      setter: 'BoolSetter'
     },
     {
       name: 'onCheck',


### PR DESCRIPTION
外层 props 不写 setter 会带来如下问题：
1. maxLength，Count 等 number 类型的 props，默认值会为 0，导致用户无法输入
2. boolean 类型的 prop，defaultValue设置为 true 无效，导致表单类组件的 border 无法显示（lowcode-demo 可复现）
3. 对于无必要的 props，不写 setter，生成的 schema 会有对应的默认值，而这个 默认值(或者说默认 prop) 是不需要的