### PR TITLE
暴露行展开事件

### DIFF
--- a/packages/antd-lowcode-materials/lowcode/table/meta.ts
+++ b/packages/antd-lowcode-materials/lowcode/table/meta.ts
@@ -824,6 +824,11 @@ export default {
           template:
             "onRowSelectionChange(selectedRowKeys,selectedRows,${extParams}){\n// 选中项发生变化时的回调\nconsole.log('onRowSelectionChange', selectedRowKeys, selectedRows);}",
         },
+        {
+          name: 'expandable.onExpand',
+          template:
+            "onExpandableExpand(expanded,record){\n// 点击展开图标时触发\nconsole.log('onRowSelectionChange', expanded, record);}",
+        },
       ],
     },
   },


### PR DESCRIPTION
我们在使用antd物料表格组件时，发现表格组件没有暴露行展开事件，导致在实现树形数据懒加载场景时遇到困难。
本次提交用于暴露行展开事件。