### PR TITLE
feat: 给几个常用的数组属性添加isRequired参数，便于在设计器上快捷输入

### DIFF
--- a/packages/antd-lowcode-materials/lowcode/auto-complete/meta.ts
+++ b/packages/antd-lowcode-materials/lowcode/auto-complete/meta.ts
@@ -226,11 +226,13 @@ export default {
                       name: 'label',
                       title: '选项名',
                       setter: 'StringSetter',
+                      isRequired: true
                     },
                     {
                       name: 'value',
                       title: '选项值',
                       setter: 'StringSetter',
+                      isRequired: true
                     },
                   ],
                 },

--- a/packages/antd-lowcode-materials/lowcode/breadcrumb/meta.ts
+++ b/packages/antd-lowcode-materials/lowcode/breadcrumb/meta.ts
@@ -37,6 +37,7 @@ export default {
                         title: { label: '路由路径', tip: 'path | 路由路径' },
                         propType: 'string',
                         setter: 'StringSetter',
+                        isRequired: true
                       },
                       {
                         name: 'breadcrumbName',
@@ -46,6 +47,7 @@ export default {
                         },
                         propType: 'string',
                         setter: 'StringSetter',
+                        isRequired: true
                       },
                     ],
                   },

--- a/packages/antd-lowcode-materials/lowcode/checkbox.group/meta.ts
+++ b/packages/antd-lowcode-materials/lowcode/checkbox.group/meta.ts
@@ -90,11 +90,13 @@ export default {
                     name: 'label',
                     title: '选项名',
                     setter: 'StringSetter',
+                    isRequired: true
                   },
                   {
                     name: 'value',
                     title: '选项值',
                     setter: 'StringSetter',
+                    isRequired: true
                   },
                   {
                     name: 'disabled',

--- a/packages/antd-lowcode-materials/lowcode/radio.group/meta.ts
+++ b/packages/antd-lowcode-materials/lowcode/radio.group/meta.ts
@@ -78,11 +78,13 @@ export default {
                     name: 'label',
                     title: '选项名',
                     setter: 'StringSetter',
+                    isRequired: true
                   },
                   {
                     name: 'value',
                     title: '选项值',
                     setter: 'StringSetter',
+                    isRequired: true
                   },
                   {
                     name: 'disabled',

--- a/packages/antd-lowcode-materials/lowcode/select/meta.ts
+++ b/packages/antd-lowcode-materials/lowcode/select/meta.ts
@@ -74,17 +74,19 @@ export default {
                   {
                     name: 'label',
                     title: '选项名',
-                    setter: ['StringSetter', 'VariableSetter']
+                    setter: ['StringSetter', 'VariableSetter'],
+                    isRequired: true
                   },
                   {
                     name: 'value',
                     title: '选项值',
                     setter: ['StringSetter', 'NumberSetter', 'VariableSetter'],
+                    isRequired: true
                   },
                   {
                     name: 'disabled',
                     title: '是否禁用',
-                    setter: ['BoolSetter', 'VariableSetter']
+                    setter: ['BoolSetter', 'VariableSetter'],
                   },
                 ],
               },


### PR DESCRIPTION
当前没有添加isRequred参数时，编辑每个选项都需要点击选项编辑按钮进行数据编辑
![image](https://user-images.githubusercontent.com/4620878/185523375-fdf720f1-7300-4328-8ea8-e2d8bfad2c6d.png)

添加isRequired参数后，可以快捷的在设计器内编辑选项
![image](https://user-images.githubusercontent.com/4620878/185523493-488c5f91-8937-49eb-a6d8-e2963ccb5c20.png)

几个常用的表单组件，可以添加此属性，方便快捷编辑选项参数
