### PR TITLE
fix: 表格列配置表达式时，数据源不能死写表达式的配置，两者是否为表达式没有必然的关系

### DIFF
--- a/packages/fusion-ui/lowcode/pro-table/pro-table-meta.ts
+++ b/packages/fusion-ui/lowcode/pro-table/pro-table-meta.ts
@@ -38,15 +38,19 @@ export const ProTableProps = [
     display: 'accordion',
     setter: (target) => {
       const columns = target.getProps().getPropValue('columns');
+      let columnsValue
       if (!columns || isJSExpression(columns)) {
-        return {
-          componentName: 'ExpressionSetter',
-        };
+        columnsValue = columns.value.replace(/^this./g, '')
+        columnsValue = columnsValue.split('.')
+        columnsValue = columnsValue.reduce((res, item) => {
+          return res[item]
+        }, target.getNode().document?.exportSchema?.('render'))
+        columnsValue = eval(columnsValue.value)
       }
       const mockRow = mockProTableRow(columns);
       const primaryKey = target.getProps().getPropValue('primaryKey') || 'id';
 
-      const items = columns.map((column, index) => {
+      const items = (columns && isJSExpression(columns) ? columnsValue : columns || []).map((column, index) => {
         return {
           title: {
             label: {


### PR DESCRIPTION
fix: 表格列配置为表达式时，数据源不能死写返回表达式的配置，两者是否为表达式没有必然的关系。只是数据源需要配置中需要获取表格列配置的值（即使是表格列的表达式，也是获取值）