### PR TITLE
fix: antd的space物料不能取消对齐方式，引起了100%宽度是子项不能撑开

### DIFF
--- a/packages/antd-lowcode-materials/lowcode/space/meta.ts
+++ b/packages/antd-lowcode-materials/lowcode/space/meta.ts
@@ -11,7 +11,7 @@ export default {
       title: { label: '对齐方式', tip: '对齐方式' },
       propType: {
         type: 'oneOf',
-        value: ['start', 'end', 'center', 'baseline'],
+        value: ['', 'start', 'end', 'center', 'baseline'],
       },
     },
     {


### PR DESCRIPTION
纵向布局，宽度撑满时 [antd组件库给的demo](https://ant.design/components/space-cn/#components-space-demo-vertical)，子元素表现为能撑满。

antd物料中使用Space时指定了flex后容器时撑开了，但是子元素不能撑满，取消algin属性的默认值就行。