### PR TITLE
In engine version 1.0.16, ProDialog and Drawer components cannot be dragged to the canvas

### DIFF
--- a/packages/fusion-lowcode-materials/lowcode/page/meta.ts
+++ b/packages/fusion-lowcode-materials/lowcode/page/meta.ts
@@ -33,11 +33,6 @@ export default [
           },
         ],
       },
-      component: {
-        isContainer: true,
-      },
-    },
-    configure: {
       supports: {
         style: true,
       },
@@ -45,7 +40,7 @@ export default [
         isContainer: true,
         disableBehaviors: '*',
         nestingRule: {
-          childWhitelist: ['NextPage'],
+          childWhitelist: ['NextPage', 'ProDialog', 'Dialog', 'Drawer'],
         },
       },
     },


### PR DESCRIPTION
In engine version 1.0.16, ProDialog and Drawer components cannot be dragged to the canvas

fixed https://github.com/alibaba/lowcode-engine/issues/1219

原因，在引擎 1.0.16 版本，修复了根节点的，即这里的 Page 节点 childWhitelist 配置没有生效的问题。

https://github.com/alibaba/lowcode-engine/pull/1168

在修复这个 bug 之后，暴露了 Page 节点不允许 'ProDialog', 'Dialog', 'Drawer' 等组件作为子组件导致相关组件无法拖拽的问题。
