### PR TITLE
[bug修复]：在windows设备上运行'npm run lowcode:dev'时 .tmp中反斜杠问题导致无法运行成功

### DIFF
--- a/packages/antd-lowcode-materials/build.lowcode.js
+++ b/packages/antd-lowcode-materials/build.lowcode.js
@@ -1,5 +1,5 @@
 const { name, version } = require("./package.json");
-
+const path  = require('path')
 const library = 'AntdLowcode';
 
 module.exports = {
@@ -65,5 +65,6 @@ module.exports = {
         ],
       },
     ],
+    [path.join(__dirname,'./command-plugins/fixTmpPlugin'),{}]
   ],
 };

--- a/packages/antd-lowcode-materials/command-plugins/fixTmpPlugin.js
+++ b/packages/antd-lowcode-materials/command-plugins/fixTmpPlugin.js
@@ -1,0 +1,23 @@
+const { exec } = require('child_process');
+
+const plugin = ({ context, registerTask, onGetWebpackConfig, onHook, log }, options) => {
+    // const { type, inject, openUrl, generateMeta = true, library } = options;
+    // const { command, rootDir, userConfig, pkg } = context;
+
+        onHook(`after.start.compile`,({isFirstCompile})=>{
+            if(isFirstCompile){
+                exec('npm run fix:tmpview', (err, stdout, stderr) => {
+                    if(err) {
+                        console.log(err);
+                        return;
+                    }
+                    console.log(`stdout: ${stdout}`);
+                    console.log(`stderr: ${stderr}`);
+                })
+            }
+        })
+
+};
+
+
+module.exports = plugin;

--- a/packages/antd-lowcode-materials/fixTmp.js
+++ b/packages/antd-lowcode-materials/fixTmp.js
@@ -1,0 +1,33 @@
+const fs = require('fs')
+const path =require('path')
+const isWindowsPlatform = () => {
+    return process.platform ==='win32'
+}
+
+const run = () => {
+    if(!isWindowsPlatform()){
+        return;
+    }
+   let tmpdirExist = fs.existsSync(path.join(__dirname,'/.tmp'))
+    if(!tmpdirExist){
+        console.log('缺少.tmp文件夹')
+        return
+    }
+    const needFixedFileNames = ['view.js','default.view.js']
+    needFixedFileNames.forEach(replaceFileWithDoubleBackSlash)
+
+}
+
+const replaceFileWithDoubleBackSlash = (fileName) => {
+    const filePath = path.join(__dirname,`./.tmp/${fileName}`)
+    const view = fs.readFileSync(filePath,'utf-8')
+    let replacedView =view.toString().replace(/\\/g,'\\\\')
+    replacedView =replacedView.replace(/\\\\\\\\/g,'\\\\')
+    fs.writeFile(filePath,replacedView,'utf-8',function (err){
+        if(!err){
+            console.log(`${fileName}反斜杠替换成功`)
+        }
+    })
+}
+
+run()

--- a/packages/antd-lowcode-materials/package.json
+++ b/packages/antd-lowcode-materials/package.json
@@ -4,6 +4,7 @@
   "description": "Antd for LowCode",
   "main": "lib/index.js",
   "scripts": {
+    "fix:tmpview": "node ./fixTmp.js",
     "build": "build-scripts build",
     "lowcode:dev": "build-scripts start --config ./build.lowcode.js",
     "lowcode:build": "build-scripts build --config ./build.lowcode.js",

--- a/packages/fusion-lowcode-materials/build.lowcode.js
+++ b/packages/fusion-lowcode-materials/build.lowcode.js
@@ -1,5 +1,5 @@
 const { name, version } = require('./package.json');
-
+const path  = require('path')
 module.exports = {
   sourceMap: false,
   alias: {
@@ -66,6 +66,7 @@ module.exports = {
         },
       },
     ],
+    [path.join(__dirname,'./command-plugins/fixTmpPlugin'),{}],
     './plugins/compatible.build.js',
   ],
 };

--- a/packages/fusion-lowcode-materials/command-plugins/fixTmpPlugin.js
+++ b/packages/fusion-lowcode-materials/command-plugins/fixTmpPlugin.js
@@ -1,0 +1,23 @@
+const { exec } = require('child_process');
+
+const plugin = ({ context, registerTask, onGetWebpackConfig, onHook, log }, options) => {
+    // const { type, inject, openUrl, generateMeta = true, library } = options;
+    // const { command, rootDir, userConfig, pkg } = context;
+
+        onHook(`after.start.compile`,({isFirstCompile})=>{
+            if(isFirstCompile){
+                exec('npm run fix:tmpview', (err, stdout, stderr) => {
+                    if(err) {
+                        console.log(err);
+                        return;
+                    }
+                    console.log(`stdout: ${stdout}`);
+                    console.log(`stderr: ${stderr}`);
+                })
+            }
+        })
+
+};
+
+
+module.exports = plugin;

--- a/packages/fusion-lowcode-materials/fixTmp.js
+++ b/packages/fusion-lowcode-materials/fixTmp.js
@@ -1,0 +1,33 @@
+const fs = require('fs')
+const path =require('path')
+const isWindowsPlatform = () => {
+    return process.platform ==='win32'
+}
+
+const run = () => {
+    if(!isWindowsPlatform()){
+        return;
+    }
+   let tmpdirExist = fs.existsSync(path.join(__dirname,'/.tmp'))
+    if(!tmpdirExist){
+        console.log('缺少.tmp文件夹')
+        return
+    }
+    const needFixedFileNames = ['view.js','default.view.js']
+    needFixedFileNames.forEach(replaceFileWithDoubleBackSlash)
+
+}
+
+const replaceFileWithDoubleBackSlash = (fileName) => {
+    const filePath = path.join(__dirname,`./.tmp/${fileName}`)
+    const view = fs.readFileSync(filePath,'utf-8')
+    let replacedView =view.toString().replace(/\\/g,'\\\\')
+    replacedView =replacedView.replace(/\\\\\\\\/g,'\\\\')
+    fs.writeFile(filePath,replacedView,'utf-8',function (err){
+        if(!err){
+            console.log(`${fileName}反斜杠替换成功`)
+        }
+    })
+}
+
+run()

--- a/packages/fusion-lowcode-materials/package.json
+++ b/packages/fusion-lowcode-materials/package.json
@@ -7,6 +7,7 @@
   "lowcodeEditMain": "build/lowcode/view.js",
   "stylePath": "style.js",
   "scripts": {
+    "fix:tmpview": "node ./fixTmp.js",
     "start": "build-scripts start",
     "build": "build-scripts build",
     "lowcode:dev": "build-scripts start --config ./build.lowcode.js",


### PR DESCRIPTION
在windows设备上运行'npm run lowcode:dev'时 .tmp中反斜杠问题导致无法运行成功
