### PR TITLE
feat(antd): antd升级visible相关属性&方法补全

### DIFF
--- a/packages/antd-lowcode-materials/lowcode/drawer/meta.ts
+++ b/packages/antd-lowcode-materials/lowcode/drawer/meta.ts
@@ -399,9 +399,9 @@ export default {
             "onClose(event,${extParams}){\n// 点击遮罩层或右上角叉或取消按钮的回调\nconsole.log('onClose',event);}",
         },
         {
-          name: 'afterVisibleChange',
+          name: 'afterOpenChange',
           template:
-            "afterVisibleChange(visible,${extParams}){\n// 切换抽屉时动画结束后的回调\nconsole.log('afterVisibleChange',visible);}",
+            "afterOpenChange(open,${extParams}){\n// 切换抽屉时动画结束后的回调\nconsole.log('afterOpenChange',open);}",
         },
       ],
     },

--- a/packages/antd-lowcode-materials/lowcode/dropdown/meta.ts
+++ b/packages/antd-lowcode-materials/lowcode/dropdown/meta.ts
@@ -108,10 +108,10 @@ export default {
       },
     },
     {
-      name: 'onVisibleChange',
+      name: 'onOpenChange',
       title: {
         label: '显示状态回调',
-        tip: '菜单显示状态改变时调用，参数为 `visible`',
+        tip: '菜单显示状态改变时调用，参数为 `open`',
       },
       propType: 'func',
     },
@@ -122,9 +122,9 @@ export default {
       style: true,
       events: [
         {
-          name: 'onVisibleChange',
+          name: 'onOpenChange',
           template:
-            "onVisibleChange(visible,${extParams}){\n// 菜单显示状态改变时调用\nconsole.log('onVisibleChange',visible);}",
+            "onOpenChange(open,${extParams}){\n// 菜单显示状态改变时调用\nconsole.log('onOpenChange',open);}",
         },
       ],
     },

--- a/packages/antd-lowcode-materials/lowcode/popover/meta.ts
+++ b/packages/antd-lowcode-materials/lowcode/popover/meta.ts
@@ -43,10 +43,10 @@ export default {
       type: 'group',
       items: [
         {
-          name: 'defaultVisible',
+          name: 'defaultOpen',
           title: {
             label: '默认显隐',
-            tip: 'defaultVisible | 默认是否显隐',
+            tip: 'defaultOpen | 默认是否显隐',
           },
           propType: 'bool',
           setter: 'BoolSetter',
@@ -311,9 +311,9 @@ export default {
       style: true,
       events: [
         {
-          name: 'onVisibleChange',
+          name: 'onOpenChange',
           template:
-            "onVisibleChange(visible,${extParams}){\n// 显示隐藏的回调\nconsole.log('onVisibleChange',visible);}",
+            "onOpenChange(open,${extParams}){\n// 显示隐藏的回调\nconsole.log('onOpenChange',open);}",
         },
       ],
     },

--- a/packages/antd-lowcode-materials/lowcode/switch/meta.ts
+++ b/packages/antd-lowcode-materials/lowcode/switch/meta.ts
@@ -14,6 +14,14 @@ export default {
       setter: 'BoolSetter'
     },
     {
+      name: 'checked',
+      title: { label: '是否选中', tip: '当前是否选中' },
+      propType: 'bool',
+      defaultValue: false,
+      setter: 'BoolSetter',
+      supportVariable: true,
+    },
+    {
       name: 'autoFocus',
       title: { label: '自动聚焦', tip: '组件自动获取焦点' },
       propType: 'bool',

--- a/packages/antd-lowcode-materials/lowcode/tag/meta.ts
+++ b/packages/antd-lowcode-materials/lowcode/tag/meta.ts
@@ -32,12 +32,12 @@ export default {
       title: { label: '关闭时的回调', tip: '关闭时的回调' },
       propType: 'func',
     },
-    {
-      name: 'visible',
-      title: { label: '是否显示标签', tip: '是否显示标签' },
-      propType: 'bool',
-      defaultValue: true,
-    },
+    // {
+    //   name: 'visible',
+    //   title: { label: '是否显示标签', tip: '是否显示标签' },
+    //   propType: 'bool',
+    //   defaultValue: true,
+    // },
     {
       name: 'icon',
       title: { label: '设置图标', tip: '设置图标' },

--- a/packages/antd-lowcode-materials/lowcode/tooltip/meta.ts
+++ b/packages/antd-lowcode-materials/lowcode/tooltip/meta.ts
@@ -28,10 +28,10 @@ export default {
       type: 'group',
       items: [
         {
-          name: 'defaultVisible',
+          name: 'defaultOpen',
           title: {
             label: '默认显隐',
-            tip: 'defaultVisible | 默认是否显隐',
+            tip: 'defaultOpen | 默认是否显隐',
           },
           propType: 'bool',
           setter: 'BoolSetter',
@@ -285,9 +285,9 @@ export default {
       style: true,
       events: [
         {
-          name: 'onVisibleChange',
+          name: 'onOpenChange',
           template:
-            "onVisibleChange(visible,${extParams}){\n// 显示隐藏的回调\nconsole.log('onVisibleChange',visible);}",
+            "onOpenChange(open,${extParams}){\n// 显示隐藏的回调\nconsole.log('onOpenChange',open);}",
         },
       ],
     },

--- a/packages/antd-lowcode-materials/package.json
+++ b/packages/antd-lowcode-materials/package.json
@@ -18,7 +18,7 @@
   ],
   "devDependencies": {
     "@alib/build-scripts": "^0.1.23",
-    "@alifd/build-plugin-lowcode": "^0.3.0",
+    "@alifd/build-plugin-lowcode": "^0.3.8",
     "@ant-design/icons": "^4.7.0",
     "@types/lodash": "^4.14.181",
     "@types/react": "^18.0.1",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/20636097/211482907-749ab1d4-09da-4c66-a28b-b97760260948.png)
- antd>=4.23.0之后visible换成了open ，相关属性补全
- tag组件废弃visible，修复编辑态中默认tag不展示问题
