### PR TITLE
fix(lowcode-materials): Cascader render error

### DIFF
--- a/packages/fusion-lowcode-materials/lowcode/cascader/meta.ts
+++ b/packages/fusion-lowcode-materials/lowcode/cascader/meta.ts
@@ -147,6 +147,7 @@ module.exports = {
         },
         {
           name: 'listStyle',
+          setter: 'ObjectSetter',
           condition: () => false,
         },
         {


### PR DESCRIPTION
解决这个 issue： https://github.com/alibaba/lowcode-engine/issues/1514

![image](https://user-images.githubusercontent.com/17904619/223614144-6909a3b6-502f-412b-bae1-208312f917d0.png)

级联组件渲染的时候，listStyle 属性需要传一个对象，但实际传了一个空字符串，类型错误导致渲染报错。

这里我给它加上 ObjectSetter，可以避免渲染报错