### PR TITLE
fix: keep componentName is identical/reletive to exportName + subName

### DIFF
--- a/packages/fusion-ui/lowcode/tab-container/meta.ts
+++ b/packages/fusion-ui/lowcode/tab-container/meta.ts
@@ -16,14 +16,14 @@ const snippets: Snippet[] = [
       },
       children: [
         {
-          componentName: 'Tab.Item',
+          componentName: 'TabContainer.Item',
           props: {
             title: '标签项1',
             primaryKey: 'tab-item-1',
           },
         },
         {
-          componentName: 'Tab.Item',
+          componentName: 'TabContainer.Item',
           props: {
             title: '标签项2',
             primaryKey: 'tab-item-2',
@@ -33,6 +33,184 @@ const snippets: Snippet[] = [
     },
   },
 ];
+
+const tabItemMeta = {
+  componentName: 'TabContainer.Item',
+  title: '选项卡',
+  docUrl: '',
+  screenshot: '',
+  devMode: 'proCode',
+  npm: {
+    package: '@alifd/fusion-ui',
+    version: '{{version}}',
+    exportName: 'TabContainer',
+    main: 'lib/index.js',
+    destructuring: true,
+    subName: 'Item',
+  },
+  configure: {
+    props: [
+      {
+        title: {
+          label: {
+            type: 'i18n',
+            'en-US': 'title',
+            'zh-CN': '选项卡标题',
+          },
+          tip: 'title | 选项卡标题',
+        },
+        name: 'title',
+        description: '选项卡标题',
+        setter: {
+          componentName: 'StringSetter',
+          isRequired: false,
+          initialValue: '',
+        },
+      },
+      {
+        title: {
+          label: {
+            type: 'i18n',
+            'en-US': 'closeable',
+            'zh-CN': '单个选项卡是否可关闭',
+          },
+          tip: 'closeable | 单个选项卡是否可关闭',
+        },
+        name: 'closeable',
+        description: '单个选项卡是否可关闭',
+        setter: {
+          componentName: 'StringSetter',
+          isRequired: false,
+          initialValue: '',
+        },
+      },
+      {
+        title: {
+          label: {
+            type: 'i18n',
+            'en-US': 'disabled',
+            'zh-CN': '选项卡是否被禁用',
+          },
+          tip: 'disabled | 选项卡是否被禁用',
+        },
+        name: 'disabled',
+        description: '选项卡是否被禁用',
+        setter: {
+          componentName: 'StringSetter',
+          isRequired: false,
+          initialValue: '',
+        },
+      },
+      {
+        title: {
+          label: {
+            type: 'i18n',
+            'en-US': 'prefix',
+            'zh-CN': '样式类名的品牌前缀',
+          },
+          tip: 'prefix | 样式类名的品牌前缀',
+        },
+        name: 'prefix',
+        description: '样式类名的品牌前缀',
+        setter: {
+          componentName: 'StringSetter',
+          isRequired: false,
+          initialValue: '',
+        },
+      },
+      {
+        title: {
+          label: {
+            type: 'i18n',
+            'en-US': 'locale',
+            'zh-CN': '国际化文案对象，属性',
+          },
+          tip: 'locale | 国际化文案对象，属性为组件的 displayName',
+        },
+        name: 'locale',
+        description: '国际化文案对象，属性为组件的 displayName',
+        setter: {
+          componentName: 'StringSetter',
+          isRequired: false,
+          initialValue: '',
+        },
+      },
+      {
+        title: {
+          label: {
+            type: 'i18n',
+            'en-US': 'pure',
+            'zh-CN': '是否开启 Pure ',
+          },
+          tip: 'pure | 是否开启 Pure Render 模式，会提高性能，但是也会带来副作用',
+        },
+        name: 'pure',
+        description: '是否开启 Pure Render 模式，会提高性能，但是也会带来副作用',
+        setter: {
+          componentName: 'StringSetter',
+          isRequired: false,
+          initialValue: '',
+        },
+      },
+      {
+        title: {
+          label: {
+            type: 'i18n',
+            'en-US': 'warning',
+            'zh-CN': '是否在开发模式下显示',
+          },
+          tip: 'warning | 是否在开发模式下显示组件属性被废弃的 warning 提示',
+        },
+        name: 'warning',
+        description: '是否在开发模式下显示组件属性被废弃的 warning 提示',
+        setter: {
+          componentName: 'StringSetter',
+          isRequired: false,
+          initialValue: '',
+        },
+      },
+      {
+        title: {
+          label: {
+            type: 'i18n',
+            'en-US': 'rtl',
+            'zh-CN': '是否开启 rtl 模',
+          },
+          tip: 'rtl | 是否开启 rtl 模式',
+        },
+        name: 'rtl',
+        description: '是否开启 rtl 模式',
+        setter: {
+          componentName: 'StringSetter',
+          isRequired: false,
+          initialValue: '',
+        },
+      },
+    ],
+    supports: {
+      events: [
+        {
+          name: 'onClick',
+        },
+        {
+          name: 'onChange',
+        },
+      ],
+      style: true,
+    },
+    component: {
+      isContainer: true,
+      disableBehaviors: '*',
+    },
+    advanced: {
+      hideSelectTools: true,
+      callbacks: {
+        onMouseDownHook: () => false,
+        onClickHook: () => false,
+      },
+    },
+  },
+};
 
 const TabContainerMeta: ComponentMetadata[] = [
   {
@@ -46,7 +224,7 @@ const TabContainerMeta: ComponentMetadata[] = [
     devMode: 'proCode',
     npm: {
       package: '@alifd/fusion-ui',
-      version: '0.1.6-beta.24',
+      version: '{{version}}',
       exportName: 'TabContainer',
       main: 'lib/index.js',
       destructuring: true,
@@ -56,7 +234,7 @@ const TabContainerMeta: ComponentMetadata[] = [
       component: {
         isContainer: true,
         nestingRule: {
-          childWhitelist: ['Tab.Item'],
+          childWhitelist: ['TabContainer.Item'],
         },
       },
       props,
@@ -66,183 +244,12 @@ const TabContainerMeta: ComponentMetadata[] = [
     },
     snippets,
   },
+  tabItemMeta,
+  // compatible with the exsting json schema which has componentName: Tab.Item
   {
+    ...tabItemMeta,
     componentName: 'Tab.Item',
-    title: '选项卡',
-    docUrl: '',
-    screenshot: '',
-    devMode: 'proCode',
-    npm: {
-      package: '@alifd/fusion-ui',
-      version: '0.1.6-beta.24',
-      exportName: 'TabContainer',
-      main: 'lib/index.js',
-      destructuring: true,
-      subName: 'Item',
-    },
-    configure: {
-      props: [
-        {
-          title: {
-            label: {
-              type: 'i18n',
-              'en-US': 'title',
-              'zh-CN': '选项卡标题',
-            },
-            tip: 'title | 选项卡标题',
-          },
-          name: 'title',
-          description: '选项卡标题',
-          setter: {
-            componentName: 'StringSetter',
-            isRequired: false,
-            initialValue: '',
-          },
-        },
-        {
-          title: {
-            label: {
-              type: 'i18n',
-              'en-US': 'closeable',
-              'zh-CN': '单个选项卡是否可关闭',
-            },
-            tip: 'closeable | 单个选项卡是否可关闭',
-          },
-          name: 'closeable',
-          description: '单个选项卡是否可关闭',
-          setter: {
-            componentName: 'StringSetter',
-            isRequired: false,
-            initialValue: '',
-          },
-        },
-        {
-          title: {
-            label: {
-              type: 'i18n',
-              'en-US': 'disabled',
-              'zh-CN': '选项卡是否被禁用',
-            },
-            tip: 'disabled | 选项卡是否被禁用',
-          },
-          name: 'disabled',
-          description: '选项卡是否被禁用',
-          setter: {
-            componentName: 'StringSetter',
-            isRequired: false,
-            initialValue: '',
-          },
-        },
-        {
-          title: {
-            label: {
-              type: 'i18n',
-              'en-US': 'prefix',
-              'zh-CN': '样式类名的品牌前缀',
-            },
-            tip: 'prefix | 样式类名的品牌前缀',
-          },
-          name: 'prefix',
-          description: '样式类名的品牌前缀',
-          setter: {
-            componentName: 'StringSetter',
-            isRequired: false,
-            initialValue: '',
-          },
-        },
-        {
-          title: {
-            label: {
-              type: 'i18n',
-              'en-US': 'locale',
-              'zh-CN': '国际化文案对象，属性',
-            },
-            tip: 'locale | 国际化文案对象，属性为组件的 displayName',
-          },
-          name: 'locale',
-          description: '国际化文案对象，属性为组件的 displayName',
-          setter: {
-            componentName: 'StringSetter',
-            isRequired: false,
-            initialValue: '',
-          },
-        },
-        {
-          title: {
-            label: {
-              type: 'i18n',
-              'en-US': 'pure',
-              'zh-CN': '是否开启 Pure ',
-            },
-            tip: 'pure | 是否开启 Pure Render 模式，会提高性能，但是也会带来副作用',
-          },
-          name: 'pure',
-          description: '是否开启 Pure Render 模式，会提高性能，但是也会带来副作用',
-          setter: {
-            componentName: 'StringSetter',
-            isRequired: false,
-            initialValue: '',
-          },
-        },
-        {
-          title: {
-            label: {
-              type: 'i18n',
-              'en-US': 'warning',
-              'zh-CN': '是否在开发模式下显示',
-            },
-            tip: 'warning | 是否在开发模式下显示组件属性被废弃的 warning 提示',
-          },
-          name: 'warning',
-          description: '是否在开发模式下显示组件属性被废弃的 warning 提示',
-          setter: {
-            componentName: 'StringSetter',
-            isRequired: false,
-            initialValue: '',
-          },
-        },
-        {
-          title: {
-            label: {
-              type: 'i18n',
-              'en-US': 'rtl',
-              'zh-CN': '是否开启 rtl 模',
-            },
-            tip: 'rtl | 是否开启 rtl 模式',
-          },
-          name: 'rtl',
-          description: '是否开启 rtl 模式',
-          setter: {
-            componentName: 'StringSetter',
-            isRequired: false,
-            initialValue: '',
-          },
-        },
-      ],
-      supports: {
-        events: [
-          {
-            name: 'onClick',
-          },
-          {
-            name: 'onChange',
-          },
-        ],
-        style: true,
-      },
-      component: {
-        isContainer: true,
-        disableBehaviors: '*',
-      },
-      advanced: {
-        hideSelectTools: true,
-        callbacks: {
-          onMouseDownHook: () => false,
-          onClickHook: () => false,
-        },
-      },
-    },
-  },
+  }
 ];
 
 export default TabContainerMeta;

--- a/packages/fusion-ui/package.json
+++ b/packages/fusion-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alifd/fusion-ui",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A component library based on Fusion Next",
   "files": [
     "es/",


### PR DESCRIPTION
当 componentName 跟所属模块的 exportName 和 subName 毫无关系时，如此例：

componentName: Tab.Item
exportName: TabContainer
subName: Item

此时，在出码运行过程中，会报错，如：https://github.com/alibaba/lowcode-engine/issues/1565

修复方式有两种：
1. 将 componentName 设置成 exportName + subName；
2. 在出码中，特别处理上面的情况，个人觉得 1 这种约束是合理的，没有额外成本，建议此次先按 1 处理；