### PR TITLE
fix: Table's pagination cannot be turn off

### DIFF
--- a/packages/antd-lowcode-materials/lowcode/table/meta.ts
+++ b/packages/antd-lowcode-materials/lowcode/table/meta.ts
@@ -326,6 +326,7 @@ export default {
               if (value) {
                 target.parent.setPropValue('pagination', {
                   pageSize: 10,
+                  size: 'default'
                 });
               }
             },
@@ -404,7 +405,6 @@ export default {
           },
           propType: 'bool',
           setter: 'BoolSetter',
-          defaultValue: false,
           condition: {
             type: 'JSFunction',
             value: 'target => !!target.getProps().getPropValue("pagination")',
@@ -418,7 +418,6 @@ export default {
           },
           propType: 'bool',
           setter: 'BoolSetter',
-          defaultValue: false,
           condition: {
             type: 'JSFunction',
             value: 'target => !!target.getProps().getPropValue("pagination")',
@@ -429,7 +428,6 @@ export default {
           title: { label: '简单分页', tip: 'pagination.simple | 简单分页' },
           propType: 'bool',
           setter: 'BoolSetter',
-          defaultValue: false,
           condition: {
             type: 'JSFunction',
             value: 'target => !!target.getProps().getPropValue("pagination")',
@@ -460,7 +458,6 @@ export default {
             },
             'VariableSetter',
           ],
-          defaultValue: 'default',
           condition: {
             type: 'JSFunction',
             value: 'target => !!target.getProps().getPropValue("pagination")',


### PR DESCRIPTION
由于低代码引擎版本迭代导致bool|object类型的属性会在子属性存在默认值时无法被设置为关闭。
删除pagination的子属性默认值，其中三个为false可以直接移除，size的默认值调整为当pagination被设置为true时设置。
如下图
<img width="677" alt="image" src="https://github.com/alibaba/lowcode-materials/assets/1539586/ee9fc3c8-05f9-430d-b88a-dc10829ae277">
